### PR TITLE
chore: update ndk to r28

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
         if: contains(matrix.arch, 'android')
         id: setup-ndk
         with:
-          ndk-version: r27d
+          ndk-version: r28
           add-to-path: false
 
       # https://github.com/android/ndk/issues/2032#issuecomment-2274923977


### PR DESCRIPTION
close https://github.com/MaaAssistantArknights/MaaDeps/issues/35
似乎是ndk r29有问题，会在maa-fastdeploy的cmake环节有一个空参数导致构建失败，r28目前没有问题。
再将MaaFramework的libMaaAndroidNativeControlUnit所用的ndk也升级至28或29就完成16KB Page size优化的支持了。
测试用Android build分别在 https://github.com/Manicsteiner/MaaDeps/actions/runs/26884184192 和 https://github.com/Manicsteiner/MaaDeps/actions/runs/26884184192/attempts/1 ，由于github抽象的稳定性只跑了android build
<details>
 <summary>效果预览</summary>
原版
<img width="1272" height="2800" alt="Screenshot_2026-06-03-21-53-08-05_708f76cdf2c7449ff16a8486e0e036f6" src="https://github.com/user-attachments/assets/25850ed2-cdc9-4da9-9fd5-a9e12ec9bc33" />
自用build
<img width="1440" height="3200" alt="Screenshot_2026-06-03-21-59-05-673_com absinthe libchecker" src="https://github.com/user-attachments/assets/bd45a339-f955-4685-9acc-fd610414ea84" />
</details>

## 由 Sourcery 提供的总结

CI：
- 在 CI 工作流程中，将 Android 构建使用的 Android NDK 版本从 r27d 升级到 r28。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Bump the Android NDK version in the CI workflow from r27d to r28 for Android builds.

</details>