### PR TITLE
fix: keep RTTI and exceptions enabled on Android

### DIFF
--- a/vcpkg-overlay/ports/ncnn/portfile.cmake
+++ b/vcpkg-overlay/ports/ncnn/portfile.cmake
@@ -22,6 +22,11 @@ vcpkg_cmake_configure(
         -DNCNN_BUILD_EXAMPLES=OFF
         -DNCNN_BUILD_BENCHMARK=OFF
         -DNCNN_SHARED_LIB=${BUILD_SHARED}
+        # ncnn defaults NCNN_DISABLE_RTTI/EXCEPTION to ON on Android/iOS and adds
+        # -fno-rtti/-fno-exceptions as PUBLIC compile options, forcing them onto
+        # every consumer. MaaCore needs RTTI and exceptions, so keep them enabled.
+        -DNCNN_DISABLE_RTTI=OFF
+        -DNCNN_DISABLE_EXCEPTION=OFF
 )
 
 vcpkg_cmake_install()


### PR DESCRIPTION
## Summary by Sourcery

通过调整 vcpkg 端口配置，确保在 Android 上使用 ncnn 的工程保持启用 RTTI 和异常处理。

Bug Fixes:
- 防止在使用 ncnn vcpkg 端口的 Android 项目中，RTTI 和异常支持被无意禁用。

Build:
- 在 ncnn vcpkg 端口中进行显式配置，以在 Android 构建中保持启用 RTTI 和异常支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure RTTI and exception handling remain enabled for ncnn consumers on Android by adjusting the vcpkg port configuration.

Bug Fixes:
- Prevent RTTI and exceptions from being unintentionally disabled in Android projects consuming the ncnn vcpkg port.

Build:
- Explicitly configure the ncnn vcpkg port to keep RTTI and exception support enabled on Android builds.

</details>

Bug Fixes（错误修复）:
- 防止在 Android 上使用 ncnn 的下游项目中，RTTI 和异常被意外禁用，这些项目需要依赖这些特性。

Build（构建）:
- 调整 vcpkg 的 ncnn port 配置，在 Android 上显式保持启用 RTTI 和异常支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过调整 vcpkg 端口配置，确保在 Android 上使用 ncnn 的工程保持启用 RTTI 和异常处理。

Bug Fixes:
- 防止在使用 ncnn vcpkg 端口的 Android 项目中，RTTI 和异常支持被无意禁用。

Build:
- 在 ncnn vcpkg 端口中进行显式配置，以在 Android 构建中保持启用 RTTI 和异常支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure RTTI and exception handling remain enabled for ncnn consumers on Android by adjusting the vcpkg port configuration.

Bug Fixes:
- Prevent RTTI and exceptions from being unintentionally disabled in Android projects consuming the ncnn vcpkg port.

Build:
- Explicitly configure the ncnn vcpkg port to keep RTTI and exception support enabled on Android builds.

</details>

</details>