### PR TITLE
ci: pin macOS runner to macos-15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,11 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: ${{ matrix.os }}-latest
+    # Pin macOS to macos-15 (Apple Silicon). GitHub is rolling macos-latest over
+    # to macos-26 (Xcode 26.5 / AppleClang 21), whose libc++ marks is_pod /
+    # is_floating_point / is_signed / is_unsigned [[no_specializations]] and breaks
+    # maa-fastdeploy float16.h. Stopgap until the float16 patch covers Apple libc++>=19.
+    runs-on: ${{ matrix.os == 'macos' && 'macos-15' || format('{0}-latest', matrix.os) }}
     timeout-minutes: 720
     steps:
       - name: Windows runner hack


### PR DESCRIPTION
## Summary by Sourcery

CI:
- 将 GitHub Actions 工作流更新为在 `macos-15` 上运行 macOS 任务，而其他操作系统仍使用各自的最新运行器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update GitHub Actions workflow to run macOS jobs on macos-15 instead of macos-latest while keeping other OSes on their latest runners.

</details>